### PR TITLE
Don't check for ip address if whitelist is empty BAUTH-3 #resolve

### DIFF
--- a/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/domain/ServiceApplication.java
+++ b/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/domain/ServiceApplication.java
@@ -70,7 +70,7 @@ public class ServiceApplication extends ServiceApplication_Base {
 
     public boolean matchesIpAddress(String ipAddress) {
         Objects.requireNonNull(ipAddress);
-        return getWhitelist().contains(ipAddress);
+        return getWhitelist().isEmpty() || getWhitelist().contains(ipAddress);
     }
 
 }


### PR DESCRIPTION
For all service applications, don't check the ip address
if that service application has the ip whitelist empty
